### PR TITLE
When you use a wildcard DNS hostname, i.e. *.domain.com, the return

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 tests/credentials.py
 doc_src/_build/*
 .DS_Store
+*.egg-info

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst
+include LICENSE

--- a/route53/connection.py
+++ b/route53/connection.py
@@ -1,7 +1,8 @@
 from lxml import etree
 from route53 import xml_parsers, xml_generators
+from route53.exceptions import Route53Error
 from route53.transport import RequestsTransport
-#from route53.util import prettyprint_xml
+from route53.util import prettyprint_xml
 from route53.xml_parsers.common_change_info import parse_change_info
 
 class Route53Connection(object):
@@ -305,4 +306,10 @@ class Route53Connection(object):
         #print(prettyprint_xml(root))
 
         e_change_info = root.find('./{*}ChangeInfo')
+        if not e_change_info:
+            print 'raising error'
+            print 'm:', root.find('./{*}Message')
+            error = root.find('./{*}Error').find('./{*}Message').text
+            print 'e:', error
+            raise Route53Error(error)
         return parse_change_info(e_change_info)

--- a/route53/resource_record_set.py
+++ b/route53/resource_record_set.py
@@ -1,3 +1,4 @@
+import copy
 import hashlib
 
 from route53.change_set import ChangeSet
@@ -62,9 +63,9 @@ class ResourceRecordSet(object):
             weight=weight,
             set_identifier=set_identifier,
         )
-        self.uniq = hashlib.sha256(str(self._initial_vals)). \
-            hexdigest()
-        print self.uniq
+        hash = copy.copy(self._initial_vals)
+        del hash['connection']
+        self.uniq = hashlib.sha256(str(hash)).hexdigest()
 
     def __str__(self):
         return '<%s: %s>' % (self.__class__.__name__, self.name)

--- a/route53/resource_record_set.py
+++ b/route53/resource_record_set.py
@@ -1,3 +1,5 @@
+import hashlib
+
 from route53.change_set import ChangeSet
 from route53.exceptions import Route53Error
 
@@ -60,6 +62,9 @@ class ResourceRecordSet(object):
             weight=weight,
             set_identifier=set_identifier,
         )
+        self.uniq = hashlib.sha256(str(self._initial_vals)). \
+            hexdigest()
+        print self.uniq
 
     def __str__(self):
         return '<%s: %s>' % (self.__class__.__name__, self.name)

--- a/route53/resource_record_set.py
+++ b/route53/resource_record_set.py
@@ -1,9 +1,6 @@
-<<<<<<< HEAD
 import copy
 import hashlib
-=======
 import re
->>>>>>> 1afcf0731bcc67b8f57822dea408548e225ebf28
 
 from route53.change_set import ChangeSet
 from route53.exceptions import Route53Error

--- a/route53/transport.py
+++ b/route53/transport.py
@@ -183,6 +183,7 @@ class RequestsTransport(BaseTransport):
         """
 
         r = requests.get(self.endpoint + path, params=params, headers=headers)
+        r.raise_for_status()
         return r.text
 
     def _send_post_request(self, path, data, headers):

--- a/route53/xml_parsers/common_change_info.py
+++ b/route53/xml_parsers/common_change_info.py
@@ -14,7 +14,6 @@ def parse_change_info(e_change_info):
     :rtype: dict
     :returns: A dict representation of the change info.
     """
-
     id = e_change_info.find('./{*}Id').text
     status = e_change_info.find('./{*}Status').text
     submitted_at = e_change_info.find('./{*}SubmittedAt').text

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,6 @@ setup(
     long_description=LONG_DESCRIPTION,
     platforms=['any'],
     classifiers=CLASSIFIERS,
-    install_requires=['requests==0.14.1', 'lxml', 'pytz'],
+    #install_requires=['requests==0.14.1', 'lxml', 'pytz'],
+    install_requires=['requests', 'lxml', 'pytz'],
 )


### PR DESCRIPTION
value is \052.domain.com. which needs to be cleaned up. There are a
few other octal values that need to be handled.  Boto faces the same
issue: https://github.com/boto/boto/pull/1216 with a suggested fix
from a gist: https://gist.github.com/meonkeys/4482362#file-route53octals-py-L13

Test code for a single record set along with tests to mirror the gist
were added.