### PR TITLE
AAAA Records should work as A records

### DIFF
--- a/route53/resource_record_set.py
+++ b/route53/resource_record_set.py
@@ -190,7 +190,7 @@ class AResourceRecordSet(ResourceRecordSet):
         return self.alias_hosted_zone_id or self.alias_dns_name
 
 
-class AAAAResourceRecordSet(ResourceRecordSet):
+class AAAAResourceRecordSet(AResourceRecordSet):
     """
     Specific AAAA record class. Create these via
     :py:meth:`HostedZone.create_aaaa_record <route53.hosted_zone.HostedZone.create_aaaa_record>`.


### PR DESCRIPTION
Traceback for an AAAA record :

```
  File "/usr/lib64/python2.7/site-packages/route53/hosted_zone.py", line 84, in record_sets
    for rrset in self.connection._list_resource_record_sets_by_zone_id(self.id):
  File "/usr/lib64/python2.7/site-packages/route53/connection.py", line 90, in _do_autopaginating_api_call
    for record in parser_func(root, connection=self, **parser_kwargs):
  File "/usr/lib64/python2.7/site-packages/route53/xml_parsers/list_resource_record_sets_by_zone_id.py", line 140, in list_resource_record_sets_by_zone_id_parser
    yield parse_rrset(e_rrset, connection, zone_id)
  File "/usr/lib64/python2.7/site-packages/route53/xml_parsers/list_resource_record_sets_by_zone_id.py", line 117, in parse_rrset
    return RRSetSubclass(**kwargs)
TypeError: __init__() got an unexpected keyword argument 'alias_hosted_zone_id'
```
