### PR TITLE
Copy records during _initial_vals create

### DIFF
--- a/route53/resource_record_set.py
+++ b/route53/resource_record_set.py
@@ -55,7 +55,7 @@ class ResourceRecordSet(object):
             zone_id=zone_id,
             name=name,
             ttl=ttl,
-            records=records,
+            records=records[:],
             region=region,
             weight=weight,
             set_identifier=set_identifier,
@@ -89,7 +89,7 @@ class ResourceRecordSet(object):
             and ``False`` if not.
         """
 
-        for key, val in self._initial_vals:
+        for key, val in self._initial_vals.items():
             if getattr(self, key) != val:
                 # One of the initial values doesn't match, we know
                 # this object has been touched.

--- a/route53/xml_generators/change_resource_record_set.py
+++ b/route53/xml_generators/change_resource_record_set.py
@@ -5,7 +5,7 @@ from route53.util import prettyprint_xml
 def get_change_values(change):
     """
     In the case of deletions, we pull the change values for the XML request
-    from the ResourceRecordSet._initial_vas dict, since we want the original
+    from the ResourceRecordSet._initial_vals dict, since we want the original
     values. For creations, we pull from the attributes on ResourceRecordSet.
 
     Since we're dealing with attributes vs. dict key/vals, we'll abstract

--- a/route53/xml_parsers/common_change_info.py
+++ b/route53/xml_parsers/common_change_info.py
@@ -15,7 +15,9 @@ def parse_change_info(e_change_info):
     :returns: A dict representation of the change info.
     """
 
-    id = e_change_info.find('./{*}Id').text
+    if e_change_info is None:
+        return e_change_info
+
     status = e_change_info.find('./{*}Status').text
     submitted_at = e_change_info.find('./{*}SubmittedAt').text
     submitted_at = parse_iso_8601_time_str(submitted_at)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -135,7 +135,7 @@ class ResourceRecordSetTestCase(BaseTestCase):
         )
         self.assertIsInstance(change_info, dict)
 
-        new_record.values = ['8.8.8.7']
+        new_record.records = ['8.8.8.7']
         new_record.save()
 
         # Initial values should equal current values after the save.


### PR DESCRIPTION
`_initial_vals` was seeded with a reference to the objects `records` dict,
which meant that it was not actually storing the initial values. The
route53 API requires DELETEs to provide the entire existing objects
values, so this bug was preventing record changing via `.save()` to work.

`_initial_vals.records` is now a copy of the `records` object, and the
`change_existing_rrset` test has been updated to use the appropriate
attribute for testing (the `values` attribute was not actually being
honored by the route53 API)

Additionally the `is_modified` check was trying to enumerate `_initial_vals`
inappropriately, `.items()` call added