### PR TITLE
Upgrade requests dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==0.14.1
+requests==2.10
 pytz
 nose
 lxml


### PR DESCRIPTION
Requests 0.14.1is old version from 2012. On the last version of requests (2.10) route53 works fine.